### PR TITLE
fillRect draws without path

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -127,9 +127,7 @@ const getIndex = (row, column) => {
 
 const drawCells = () => {
   const cellsPtr = universe.cells();
-  const cells = new Uint8Array(memory.buffer, cellsPtr, width * height);
-
-  ctx.beginPath();
+  const cells = new Uint8Array(memory.buffer, cellsPtr, width * height);  
 
   // Alive cells.
   ctx.fillStyle = ALIVE_COLOR;
@@ -166,8 +164,6 @@ const drawCells = () => {
       );
     }
   }
-
-  ctx.stroke();
 };
 
 canvas.addEventListener("click", event => {


### PR DESCRIPTION
`fillRect` draws independently of current path.

Ref: for instance MDN [CanvasRenderingContext2D: fillRect() method](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillRect) states

> This method draws directly to the canvas without modifying the current path …